### PR TITLE
 Apply Forwards to all hosts and abbriviated hostnames 

### DIFF
--- a/user-guide/connecting.rst
+++ b/user-guide/connecting.rst
@@ -5,7 +5,7 @@ The following stanza is required in your local ``~/.ssh/config`` in order to tra
 
 .. code-block:: text
 
-  Host isambard.gw4.ac.uk
+  Host *isambard.gw4.ac.uk *isambard
     User XX-USERNAME
     ForwardAgent yes
     ForwardX11 yes

--- a/user-guide/jobs.rst
+++ b/user-guide/jobs.rst
@@ -15,9 +15,9 @@ Queue configuration
 
 * arm     - Run on 164x Thunder X2 XC50 compute nodes
 * arm-dev - Run interatively on up to 4x Thunder X2 XC50 compute nodes
-* knl     - Run on 8x Intel Xeon Phi "Knights Landing" 7210 CPU nodes
-* pascal  - Run on 4x dual-card Nvidia Tesla P100 "Pascal" GPU nodes
-* power   - Run on 2x IBM Power 9 nodes, each with dual-card Nvidia V100 "Volta" GPUs ← ``Queue unavailable, interactive use only, hosts: power-001, power-002``
+* knlq    - Run on 8x Intel Xeon Phi "Knights Landing" 7210 CPU nodes
+* pascalq - Run on 4x dual-card Nvidia Tesla P100 "Pascal" GPU nodes
+* powerq  - Run on 2x IBM Power 9 nodes, each with dual-card Nvidia V100 "Volta" GPUs ← ``Queue unavailable, interactive use only, hosts: power-001, power-002``
 
 knlq is split into two sets of MCDRAM configuration, nodes 001-004 are in cache memory mode (quad_0) and nodes 005-008 are in flat memory mode (quad_100). These modes can be targeted using the ``aoe=`` PBS attribute.
 
@@ -35,7 +35,7 @@ Phase 1 example:
 .. code-block:: bash
 
  #!/bin/bash
- #PBS -q pascal
+ #PBS -q pascalq
  #PBS -l select=2
  #PBS -l walltime=00:01:00
  
@@ -76,7 +76,7 @@ For example, this command declares that your job will run on a single node and w
 
 .. code-block:: bash
 
-  qsub -I -q pascal -l select=1:ngpus=1
+  qsub -I -q pascalq -l select=1:ngpus=1
 
 If you request `ngpus=2`, then any subsequently submitted job requesting a GPU will not run on the same node until a node is freed. Similarly setting `ncpus=36` will block any jobs from running.
 


### PR DESCRIPTION
SSH config for X11Forward & ForwardAgent only apply to the bastions and don't affect the abbreviated hostnames such as "xci.isambard" as they don't end in "isambard.gw4.ac.uk"