### PR TITLE
Doc update - Connecting to Isambard / Power9

### DIFF
--- a/user-guide/connecting.rst
+++ b/user-guide/connecting.rst
@@ -10,35 +10,27 @@ The following stanza is required in your local ``~/.ssh/config`` in order to tra
 
 .. code-block:: text
 
-  Host *isambard.gw4.ac.uk *isambard
-    User XX-USERNAME
-    ForwardAgent yes
-    ForwardX11 yes
-    IdentityFile ~/.ssh/id_rsa
-  
-  Host login-01.isambard.gw4.ac.uk login-01.isambard login.isambard
-    Hostname login-01
-    User XX-USERNAME
-    IdentityFile ~/.ssh/id_rsa
-    ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
-  
-  Host login-02.isambard.gw4.ac.uk login-02.isambard
-    Hostname login-02
-    User XX-USERNAME
-    IdentityFile ~/.ssh/id_rsa
-    ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
-  
-  Host xcil00.isambard.gw4.ac.uk xcil00.isambard xci.isambard
-    Hostname xcil00
-    User XX-USERNAME
-    IdentityFile ~/.ssh/id_rsa
-    ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
-  
-  Host xcil01.isambard.gw4.ac.uk xcil01.isambard
-    Hostname xcil01
-    User XX-USERNAME
-    IdentityFile ~/.ssh/id_rsa
-    ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
+ Host *isambard.gw4.ac.uk *isambard
+   User XX-USERNAME
+   ForwardAgent yes
+   ForwardX11 yes
+   IdentityFile ~/.ssh/id_rsa
+
+ Host login-01.isambard.gw4.ac.uk login-01.isambard login.isambard
+   Hostname login-01
+   ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
+
+ Host login-02.isambard.gw4.ac.uk login-02.isambard
+   Hostname login-02
+   ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
+
+ Host xcil00.isambard.gw4.ac.uk xcil00.isambard xci.isambard
+   Hostname xcil00
+   ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
+
+ Host xcil01.isambard.gw4.ac.uk xcil01.isambard
+   Hostname xcil01
+   ProxyCommand ssh isambard.gw4.ac.uk 'nc %h %p'
 
 .. caution::
   Update the ``~/.ssh/config`` with your details:-

--- a/user-guide/phase1.rst
+++ b/user-guide/phase1.rst
@@ -61,7 +61,7 @@ IBM Power 9
 
 Isambard's Power nodes comprise two of `IBM Power System AC922 <https://www.ibm.com/uk-en/marketplace/power-systems-ac922>`_ , they are representative of the type of node used in large-scale HPC. Each node has the IBM XL C/C++ (``xlc``) & IBM XL Fortran (``xlf``) compilers installed. To make full use of each node's two Nvidia V100 "Volta" GPUs we have installed the `IBM PowerAI <https://developer.ibm.com/linuxonpower/deep-learning-powerai/>`_ stack for Machine Learning research.
 
-These nodes are available interactively via SSH. Access is available from `login-01` or `login-02` since these nodes are only connected the Infiniband network.
+.. note:: These nodes are available interactively via SSH (i.e without submitting to the scheduler). Access is available from ``login-01`` or ``login-02`` since these nodes are only connected the Infiniband network.
 
 .. code-block:: text
 


### PR DESCRIPTION
1. The `*isambard.gw4.ac.uk` and `*isambard`  allowed removing some of the repeating details with each `Host` section
2. Re-formatted information on access to Power9