### PR TITLE
Update debugging pages

### DIFF
--- a/tools/ddt.rst
+++ b/tools/ddt.rst
@@ -1,7 +1,10 @@
+.. _ddt:
+
 Arm DDT
 =======
 
-DDT is a tool for debugging C, C++ and Fortran parallel programs. It is available on both phase 1 and phase 2 as part of the Forge suite.
+DDT is a tool for debugging C, C++ and Fortran parallel programs. It
+is available on the MACS and XCI systems as part of the Forge suite.
 
 Useful links
 -------------
@@ -11,12 +14,12 @@ A User Guide and Getting Started guide are available from https://developer.arm.
 Modules
 ---------
 
-To use DDT you will need to load the Forge module. On phase 1 the command is
+To use DDT you will need to load the Forge module. On MACS the command is
 ::
 
   module load allinea/forge
 
-and on phase 2 the command is
+and on the XCI system the command is
 ::
 
   module load tools/arm-forge
@@ -26,25 +29,31 @@ When you have loaded the module you can start the DDT graphical interface by run
 Example session
 ----------------
 
-This example uses an interactive job running in the phase 2 ``arm-dev`` queue to debug a parallel program.
+This example uses an interactive job running in the XCI ``arm-dev`` queue to debug a parallel program.
 
 Start by compiling your program with a ``-g`` flag to retain extra debugging information. For example to compile a C program called ``myprog.c`` run
 ::
-  cc -g -o myprog myprog.c
+
+   cc -g -o myprog myprog.c
+
 which will produce an executable file called ``myprog``.
 
 Next start an interactive job by running the command
 ::
+   
   qsub -I -X -q arm-dev -l select=1 -l walltime=1:00:00
+
 This starts an interactive job (``-I``) with X11 graphics forwarding (``-X``) using 1 compute node for up to 1 hour. 
 
 When the job starts load the Forge module
 ::
+   
   module load tools/arm-forge
+
 We can now run ``ddt`` and tell it to start our program
 ::
+   
   ddt aprun -n 2 ./myprog
+
 This example runs ``myprog`` with with 2 MPI processes. The ``ddt`` graphical interface will open and from here you can launch and debug your program.
-
-
 

--- a/tools/gdb4hpc.rst
+++ b/tools/gdb4hpc.rst
@@ -1,7 +1,10 @@
+.. _gdb4hpc:
+
 gdb4hpc
 =======
 
-gdb4hpc is a parallel debugger for C, C++ and Fortran programs and is available on both phase 1 and phase 2 as part of the Cray Programming Environment.
+gdb4hpc is a parallel debugger for C, C++ and Fortran programs and is
+available on both the MACS and XCI systems as part of the Cray Programming Environment.
 It is a command line tool (based on gdb) and it can be used either to launch an application or attach to application which is already running.
 
 Modules

--- a/user-guide/debugging.rst
+++ b/user-guide/debugging.rst
@@ -1,4 +1,8 @@
 Debugging
 =========
 
-TODO
+There are two debugging tools available on Isambard:
+:ref:`DDT <ddt>` (graphical)
+and :ref:`gdb4hpc <gdb4hpc>` (command line).
+More information can be found under the
+Development Tools section of this documentation.


### PR DESCRIPTION
Replace phase 1/2 with MACS/XCI. Also add links to DDT and gdb4hpc in top level debugging page.