### PR TITLE
MACS update affecting compiler licences

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -29,6 +29,8 @@ Maintenance
    
    Update: Work has continued into the week of 26th April, we aim to restore service as soon as possible.
 
+   Update 2: The compiler licences will also be unavailable until the MACs update is complete.
+
 System Status
 -------------
 


### PR DESCRIPTION
Just a small addition to the main page to let people know the MACS update is affecting the compiler licences.